### PR TITLE
Add pagination options to listUserStories API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -282,8 +282,11 @@ server.tool(
   'listUserStories',
   {
     projectIdentifier: z.string().describe('Project ID or slug'),
+    pageSize: z.number().optional().describe('Number of stories per page (1-100, default: 100)'),
+    page: z.number().optional().describe('Specific page number to fetch'),
+    fetchAll: z.boolean().optional().describe('Whether to fetch all stories across all pages (default: true)'),
   },
-  async ({ projectIdentifier }) => {
+  async ({ projectIdentifier, pageSize, page, fetchAll }) => {
     try {
       // Get project ID if a slug was provided
       let projectId = projectIdentifier;
@@ -292,7 +295,25 @@ server.tool(
         projectId = project.id;
       }
 
-      const userStories = await taigaService.listUserStories(projectId);
+      // Validate pageSize
+      if (pageSize !== undefined && (pageSize < 1 || pageSize > 100)) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Error: pageSize must be between 1 and 100.',
+            },
+          ],
+        };
+      }
+
+      const options = {
+        pageSize,
+        page,
+        fetchAll: fetchAll !== false // Default to true unless explicitly set to false
+      };
+
+      const userStories = await taigaService.listUserStories(projectId, options);
 
       if (userStories.length === 0) {
         return {
@@ -305,11 +326,13 @@ server.tool(
         };
       }
 
+      const paginationInfo = page !== undefined ? ` (Page ${page})` : fetchAll !== false ? ` (All ${userStories.length} stories)` : '';
+
       return {
         content: [
           {
             type: 'text',
-            text: `User Stories in Project:
+            text: `User Stories in Project${paginationInfo}:
 
 ${userStories.map(us => `- #${us.ref}: ${us.subject} (Status: ${us.status_extra_info?.name || 'Unknown'})`).join('\n')}
             `,
@@ -421,5 +444,3 @@ User Story: #${createdTask.user_story_extra_info?.ref} - ${createdTask.user_stor
 // Start the server
 const transport = new StdioServerTransport();
 await server.connect(transport);
-
-console.log('Taiga MCP server started');

--- a/src/taigaService.js
+++ b/src/taigaService.js
@@ -65,15 +65,72 @@ export class TaigaService {
   /**
    * List user stories for a project
    * @param {string} projectId - Project ID
+   * @param {Object} options - Pagination options
+   * @param {number} [options.pageSize=100] - Number of stories per page (max 100)
+   * @param {number} [options.page] - Specific page number to fetch
+   * @param {boolean} [options.fetchAll=true] - Whether to fetch all stories across all pages
    * @returns {Promise<Array>} - List of user stories
    */
-  async listUserStories(projectId) {
+  async listUserStories(projectId, options = {}) {
+    const { pageSize = 100, page, fetchAll = true } = options;
+
     try {
       const client = await createAuthenticatedClient();
+
+      // If requesting a specific page, return just that page
+      if (page !== undefined && !fetchAll) {
+        const response = await client.get('/userstories', {
+          params: {
+            project: projectId,
+            page_size: pageSize,
+            page: page
+          }
+        });
+        return response.data;
+      }
+
+      // If fetchAll is true (default), get all stories across all pages
+      if (fetchAll) {
+        let allStories = [];
+        let currentPage = 1;
+        let hasMorePages = true;
+
+        while (hasMorePages) {
+          const response = await client.get('/userstories', {
+            params: {
+              project: projectId,
+              page_size: pageSize,
+              page: currentPage
+            }
+          });
+
+          const stories = response.data;
+          allStories = allStories.concat(stories);
+
+          // Check pagination headers to see if there are more pages
+          const paginationNext = response.headers['x-pagination-next'];
+          hasMorePages = paginationNext && paginationNext !== 'null';
+          currentPage++;
+
+          // Safety check to prevent infinite loops
+          if (currentPage > 1000) {
+            console.warn('Stopped pagination after 1000 pages to prevent infinite loop');
+            break;
+          }
+        }
+
+        return allStories;
+      }
+
+      // Default single page request
       const response = await client.get('/userstories', {
-        params: { project: projectId }
+        params: {
+          project: projectId,
+          page_size: pageSize
+        }
       });
       return response.data;
+
     } catch (error) {
       console.error(`Failed to list user stories for project ${projectId}:`, error.message);
       throw new Error('Failed to list user stories from Taiga');


### PR DESCRIPTION
The listUserStories tool and TaigaService now support page size, page number, and fetchAll options for improved pagination and flexibility when retrieving user stories. Input validation and response formatting have been updated to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added pagination controls to user story listing: choose page size, request a specific page, or fetch all stories.
  - UI now indicates context: displays “(Page N)” for paged results or “(All X stories)” when fetching all.
  - Validates page size (must be 1–100) and returns a clear inline error when invalid.
  - Preserves existing story list formatting and response structure while including pagination details.
  - Improved reliability when retrieving large sets by aggregating results across pages when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->