### PR TITLE
Add server start log message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -773,4 +773,5 @@ ${tasks.map(task => `- #${task.ref}: ${task.subject} (Status: ${task.status_extr
 const transport = new StdioServerTransport();
 await server.connect(transport);
 
-console.log('Taiga MCP server started');
+console.error('Taiga MCP server started');
+


### PR DESCRIPTION
Added a console.error statement to indicate when the Taiga MCP server has started. This helps with debugging and monitoring server status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added a startup log to improve operational visibility during server initialization. This aids diagnostics and monitoring without altering functionality.
  - No user-facing changes: behavior, performance, and workflows remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->